### PR TITLE
Fix YAML example in User Guide docs

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -215,7 +215,7 @@ An example `batch` stage configuration for the `prepare_data` stage could be as 
 
 ```yaml
 stages:
-  model_scoring_service:
+  prepare_data:
     ...
     batch:
       max_completion_time_seconds: 30


### PR DESCRIPTION
In User Guide, [here](https://bodywork.readthedocs.io/en/latest/user_guide/#batch-stages) it says:

> An example batch stage configuration for the **prepare_data** stage could be as follows,

but the following example shows batch stage named `model_scoring_service`. This seems like a mistake, so I fixed it.